### PR TITLE
Scoreboard null check

### DIFF
--- a/src/main/java/org/dimdev/vanillafix/bugs/mixins/client/MixinNetHandlerPlayClient.java
+++ b/src/main/java/org/dimdev/vanillafix/bugs/mixins/client/MixinNetHandlerPlayClient.java
@@ -36,7 +36,7 @@ public abstract class MixinNetHandlerPlayClient implements INetHandlerPlayClient
 
             Scoreboard scoreboard = world.getScoreboard();
             world = new WorldClient((NetHandlerPlayClient) (Object) this, new WorldSettings(0L, packetIn.getGameType(), false, client.world.getWorldInfo().isHardcoreModeEnabled(), packetIn.getWorldType()), packetIn.getDimensionID(), packetIn.getDifficulty(), client.profiler);
-            world.setWorldScoreboard(scoreboard);
+            if (scoreboard != null) world.setWorldScoreboard(scoreboard);
             client.loadWorld(world);
             client.player.dimension = packetIn.getDimensionID();
         }


### PR DESCRIPTION
In very rare occurrences the scoreboard can be null. This makes it so players are unable to join because the packet fails